### PR TITLE
Remove Tag on Cancel

### DIFF
--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -401,6 +401,7 @@ class ConvertKit_MM_Admin {
 				CONVERTKIT_MM_NAME . '-ck-mapping-membership-levels',
 				array(
 					'key'          => $key,
+					'type'		   => __( 'Level', 'convertkit-mm' ),
 
 					'name'         => 'convertkit-mapping-' . $key,
 					'value'        => $this->settings->get_membership_level_mapping( $key ),
@@ -459,6 +460,7 @@ class ConvertKit_MM_Admin {
 				CONVERTKIT_MM_NAME . '-ck-mapping-products',
 				array(
 					'key'     => $key,
+					'type'	  => __( 'Product', 'convertkit-mm' ),
 
 					'name'    => 'convertkit-mapping-product-' . $key,
 					'value'   => $this->settings->get_product_mapping( $key ),
@@ -515,6 +517,7 @@ class ConvertKit_MM_Admin {
 				CONVERTKIT_MM_NAME . '-ck-mapping-bundles',
 				array(
 					'key'          => $key,
+					'type'		   => __( 'Bundle', 'convertkit-mm' ),
 
 					'name'         => 'convertkit-mapping-bundle-' . $key,
 					'value'        => $this->settings->get_bundle_mapping( $key ),
@@ -756,7 +759,8 @@ class ConvertKit_MM_Admin {
 			$args['name_cancel'],
 			$args['value_cancel'],
 			$args['options'],
-			__( 'Apply tag on cancel', 'convertkit-mm' )
+			__( 'Apply / remove tag on cancel', 'convertkit-mm' ),
+			true
 		);
 
 		echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -768,13 +772,14 @@ class ConvertKit_MM_Admin {
 	 *
 	 * @since   1.3.0
 	 *
-	 * @param   string      $name            Name.
-	 * @param   string      $value           Value.
-	 * @param   array       $options         Options / Choices.
-	 * @param   bool|string $label           Label.
-	 * @return  string                           HTML Select Field
+	 * @param   string      $name            		Name.
+	 * @param   string      $value           		Value.
+	 * @param   array       $options         		Options / Choices.
+	 * @param   bool|string $label           		Label.
+	 * @param 	bool 		$show_remove_options 	Show 'Remove Tag' options.
+	 * @return  string                           	HTML Select Field
 	 */
-	private function get_select_field( $name, $value = '', $options = array(), $label = false ) {
+	private function get_select_field( $name, $value = '', $options = array(), $label = false, $show_remove_options = false ) {
 
 		$html = '';
 
@@ -801,7 +806,11 @@ class ConvertKit_MM_Admin {
 			esc_attr__( '(None)', 'convertkit-mm' )
 		);
 
-		// Build <option> tags.
+		// Tags: Assign.
+		$html .= sprintf(
+			'<optgroup label="%s">',
+			__( 'Assign Tag', 'convertkit-mm' )
+		);
 		foreach ( $options as $option ) {
 			$html .= sprintf(
 				'<option value="%s"%s>%s</option>',
@@ -809,6 +818,25 @@ class ConvertKit_MM_Admin {
 				selected( $value, $option['id'], false ),
 				$option['name']
 			);
+		}
+		$html .= '</optgroup>';
+
+		// Tags: Remove.
+		if ( $show_remove_options ) {
+			$html .= sprintf(
+				'<optgroup label="%s">',
+				__( 'Remove Tag', 'convertkit-mm' )
+			);
+			foreach ( $options as $option ) {
+				$html .= sprintf(
+					'<option value="%s-remove"%s>%s (%s)</option>',
+					$option['id'],
+					selected( $value, $option['id'] . '-remove', false ),
+					$option['name'],
+					__( 'Remove', 'convertkit-mm' )
+				);
+			}
+			$html .= '</optgroup>';
 		}
 
 		// Close <select>.

--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -401,7 +401,7 @@ class ConvertKit_MM_Admin {
 				CONVERTKIT_MM_NAME . '-ck-mapping-membership-levels',
 				array(
 					'key'          => $key,
-					'type'		   => __( 'Level', 'convertkit-mm' ),
+					'type'         => __( 'Level', 'convertkit-mm' ),
 
 					'name'         => 'convertkit-mapping-' . $key,
 					'value'        => $this->settings->get_membership_level_mapping( $key ),
@@ -460,7 +460,7 @@ class ConvertKit_MM_Admin {
 				CONVERTKIT_MM_NAME . '-ck-mapping-products',
 				array(
 					'key'     => $key,
-					'type'	  => __( 'Product', 'convertkit-mm' ),
+					'type'    => __( 'Product', 'convertkit-mm' ),
 
 					'name'    => 'convertkit-mapping-product-' . $key,
 					'value'   => $this->settings->get_product_mapping( $key ),
@@ -517,7 +517,7 @@ class ConvertKit_MM_Admin {
 				CONVERTKIT_MM_NAME . '-ck-mapping-bundles',
 				array(
 					'key'          => $key,
-					'type'		   => __( 'Bundle', 'convertkit-mm' ),
+					'type'         => __( 'Bundle', 'convertkit-mm' ),
 
 					'name'         => 'convertkit-mapping-bundle-' . $key,
 					'value'        => $this->settings->get_bundle_mapping( $key ),
@@ -772,12 +772,12 @@ class ConvertKit_MM_Admin {
 	 *
 	 * @since   1.3.0
 	 *
-	 * @param   string      $name            		Name.
-	 * @param   string      $value           		Value.
-	 * @param   array       $options         		Options / Choices.
-	 * @param   bool|string $label           		Label.
-	 * @param 	bool 		$show_remove_options 	Show 'Remove Tag' options.
-	 * @return  string                           	HTML Select Field
+	 * @param   string      $name                   Name.
+	 * @param   string      $value                  Value.
+	 * @param   array       $options                Options / Choices.
+	 * @param   bool|string $label                  Label.
+	 * @param   bool        $show_remove_options    Show 'Remove Tag' options.
+	 * @return  string                              HTML Select Field
 	 */
 	private function get_select_field( $name, $value = '', $options = array(), $label = false, $show_remove_options = false ) {
 

--- a/includes/class-convertkit-mm-actions.php
+++ b/includes/class-convertkit-mm-actions.php
@@ -144,9 +144,16 @@ class ConvertKit_MM_Actions {
 			return;
 		}
 
+		// If the Tag contains `-remove`, we need to remove the Tag from the subscriber.
+		if ( strpos( $tag_id, '-remove' ) !== false ) {
+			$this->remove_tag_from_user( $user_email, $tag_id );
+			convertkit_mm_log( 'tag', 'Remove tag ' . $tag_id . ' from user ' . $user_email . ' (' . $first_name . ')' );
+			return;
+		}
+
 		// Subscribe and tag.
 		$this->add_tag_to_user( $user_email, $first_name, $tag_id );
-		convertkit_mm_log( 'tag', 'Delete tag ' . $tag_id . ' to user ' . $user_email . ' (' . $first_name . ')' );
+		convertkit_mm_log( 'tag', 'Add tag ' . $tag_id . ' to user ' . $user_email . ' (' . $first_name . ')' );
 
 	}
 
@@ -174,9 +181,16 @@ class ConvertKit_MM_Actions {
 			return;
 		}
 
+		// If the Tag contains `-remove`, we need to remove the Tag from the subscriber.
+		if ( strpos( $tag_id, '-remove' ) !== false ) {
+			$this->remove_tag_from_user( $user_email, $tag_id );
+			convertkit_mm_log( 'tag', 'Remove tag ' . $tag_id . ' from user ' . $user_email . ' (' . $first_name . ')' );
+			return;
+		}
+
 		// Subscribe and tag.
 		$this->add_tag_to_user( $user_email, $first_name, $tag_id );
-		convertkit_mm_log( 'tag', 'Delete tag ' . $tag_id . ' to user ' . $user_email . ' (' . $user_name . ')' );
+		convertkit_mm_log( 'tag', 'Add tag ' . $tag_id . ' to user ' . $user_email . ' (' . $user_name . ')' );
 
 	}
 
@@ -264,6 +278,13 @@ class ConvertKit_MM_Actions {
 			return;
 		}
 
+		// If the Tag contains `-remove`, we need to remove the Tag from the subscriber.
+		if ( strpos( $tag_id, '-remove' ) !== false ) {
+			$this->remove_tag_from_user( $user_email, $tag_id );
+			convertkit_mm_log( 'tag', 'Remove bundle tag ' . $tag_id . ' from user ' . $user_email . ' (' . $first_name . ')' );
+			return;
+		}
+
 		// Assign tag to subscriber in ConvertKit.
 		$this->add_tag_to_user( $user_email, $first_name, $tag_id );
 		convertkit_mm_log( 'tag', 'Add bundle tag ' . $tag_id . ' to user ' . $user_email . ' (' . $first_name . ')' );
@@ -301,6 +322,31 @@ class ConvertKit_MM_Actions {
 
 		// Tag subscriber.
 		$api->tag_subscriber( absint( $tag_id ), $subscriber['subscriber']['id'] );
+
+	}
+
+	/**
+	 * Initializes the API, removing the Tag ID from the subscriber on Kit.
+	 *
+	 * @since   1.X.X
+	 *
+	 * @param   string $email          Email Address.
+	 * @param   int    $tag_id         Tag ID.
+	 */
+	private function remove_tag_from_user( $email, $tag_id ) {
+
+		// Initialize the API.
+		$api = new ConvertKit_MM_API(
+			CONVERTKIT_MM_OAUTH_CLIENT_ID,
+			CONVERTKIT_MM_OAUTH_CLIENT_REDIRECT_URI,
+			$this->settings->get_access_token(),
+			$this->settings->get_refresh_token(),
+			$this->settings->debug_enabled(),
+			'settings'
+		);
+
+		// Remove tag from subscriber.
+		$api->remove_tag_from_subscriber_by_email( absint( $tag_id ), $email );
 
 	}
 

--- a/includes/class-convertkit-mm-actions.php
+++ b/includes/class-convertkit-mm-actions.php
@@ -328,7 +328,7 @@ class ConvertKit_MM_Actions {
 	/**
 	 * Initializes the API, removing the Tag ID from the subscriber on Kit.
 	 *
-	 * @since   1.X.X
+	 * @since   1.2.8
 	 *
 	 * @param   string $email          Email Address.
 	 * @param   int    $tag_id         Tag ID.

--- a/tests/acceptance/bundle/BundleTagCest.php
+++ b/tests/acceptance/bundle/BundleTagCest.php
@@ -171,7 +171,7 @@ class BundleTagCest
 	/**
 	 * Test that the member has a tag removed when their bundle is cancelled.
 	 *
-	 * @since   1.X.X
+	 * @since   1.2.8
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */

--- a/tests/acceptance/bundle/BundleTagCest.php
+++ b/tests/acceptance/bundle/BundleTagCest.php
@@ -169,6 +169,53 @@ class BundleTagCest
 	}
 
 	/**
+	 * Test that the member has a tag removed when their bundle is cancelled.
+	 *
+	 * @since   1.X.X
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMemberTagRemovedWhenBundleCancelled(AcceptanceTester $I)
+	{
+		// Create a product.
+		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+
+		// Create bundle.
+		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+
+		// Setup Plugin to tag users purchasing the bundle to the
+		// ConvertKit Tag ID.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'convertkit-mapping-bundle-' . $bundleID => $_ENV['CONVERTKIT_API_TAG_ID'],
+				'convertkit-mapping-bundle-' . $bundleID . '-cancel' => $_ENV['CONVERTKIT_API_TAG_ID'] . '-remove',
+			]
+		);
+
+		// Generate email address for test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create member.
+		$I->memberMouseCreateMember($I, $emailAddress);
+
+		// Assign bundle.
+		$I->memberMouseAssignBundleToMember($I, $emailAddress, 'Bundle');
+
+		// Check subscriber exists.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+
+		// Cancel the user's bundle.
+		$I->memberMouseCancelMemberBundle($I, $emailAddress, 'Bundle');
+
+		// Check that the subscriber is no longer assigned to the tag.
+		$I->apiCheckSubscriberHasNoTags($I, $subscriberID);
+	}
+
+	/**
 	 * Test that the member is not tagged when the configured "apply tag on add"
 	 * setting is "none" for the given bundle.
 	 *

--- a/tests/acceptance/member/MemberTagCest.php
+++ b/tests/acceptance/member/MemberTagCest.php
@@ -160,7 +160,7 @@ class MemberTagCest
 	/**
 	 * Test that the member has a tag removed when their membership level is cancelled.
 	 *
-	 * @since   1.X.X
+	 * @since   1.2.8
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */
@@ -263,7 +263,7 @@ class MemberTagCest
 	/**
 	 * Test that the member has a tag removed when their membership is deleted.
 	 *
-	 * @since   1.X.X
+	 * @since   1.2.8
 	 *
 	 * @param   AcceptanceTester $I  Tester.
 	 */

--- a/tests/acceptance/member/MemberTagCest.php
+++ b/tests/acceptance/member/MemberTagCest.php
@@ -158,6 +158,57 @@ class MemberTagCest
 	}
 
 	/**
+	 * Test that the member has a tag removed when their membership level is cancelled.
+	 *
+	 * @since   1.X.X
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMemberTagRemovedWhenMembershipLevelCancelled(AcceptanceTester $I)
+	{
+		// Setup Plugin to tag users added to the Free Membership level to the
+		// ConvertKit Tag ID, and remove the tag when their membership
+		// is cancelled.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'convertkit-mapping-1'        => $_ENV['CONVERTKIT_API_TAG_ID'],
+				'convertkit-mapping-1-cancel' => $_ENV['CONVERTKIT_API_TAG_ID'] . '-remove',
+			]
+		);
+
+		// Generate email address for test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create member.
+		$I->memberMouseCreateMember($I, $emailAddress);
+
+		// Check subscriber exists.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+
+		// Cancel the user's membership level.
+		$I->amOnAdminPage('admin.php?page=manage_members');
+		$I->click($emailAddress);
+		$I->click('Access Rights');
+		$I->click('Cancel Membership');
+
+		// Accept popups
+		// We have to wait as there's no specific event MemberMouse fires to tell
+		// us it completed changing the membership level.
+		$I->wait(5);
+		$I->acceptPopup();
+		$I->wait(5);
+		$I->acceptPopup();
+		$I->wait(5);
+
+		// Check that the subscriber is no longer assigned to the tag.
+		$I->apiCheckSubscriberHasNoTags($I, $subscriberID);
+	}
+
+	/**
 	 * Test that the member is tagged with the configured "apply tag on cancelled"
 	 * setting when deleted.
 	 *
@@ -207,6 +258,56 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the cancelled tag.
 		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']);
+	}
+
+	/**
+	 * Test that the member has a tag removed when their membership is deleted.
+	 *
+	 * @since   1.X.X
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testMemberTagRemovedWhenDeleted(AcceptanceTester $I)
+	{
+		// Setup Plugin to tag users added to the Free Membership level to the
+		// ConvertKit Tag ID, and remove the tag when their membership
+		// is deleted.
+		$I->setupConvertKitPlugin(
+			$I,
+			[
+				'convertkit-mapping-1'        => $_ENV['CONVERTKIT_API_TAG_ID'],
+				'convertkit-mapping-1-cancel' => $_ENV['CONVERTKIT_API_TAG_ID'] . '-remove',
+			]
+		);
+
+		// Generate email address for test.
+		$emailAddress = $I->generateEmailAddress();
+
+		// Create member.
+		$I->memberMouseCreateMember($I, $emailAddress);
+
+		// Check subscriber exists.
+		$subscriberID = $I->apiCheckSubscriberExists($I, $emailAddress);
+
+		// Check that the subscriber has been assigned to the tag.
+		$I->apiCheckSubscriberHasTag($I, $subscriberID, $_ENV['CONVERTKIT_API_TAG_ID']);
+
+		// Cancel the user's membership level.
+		$I->amOnAdminPage('admin.php?page=manage_members');
+		$I->click($emailAddress);
+		$I->click('Delete Member');
+
+		// Accept popups
+		// We have to wait as there's no specific event MemberMouse fires to tell
+		// us it completed changing the membership level.
+		$I->wait(5);
+		$I->acceptPopup();
+		$I->wait(5);
+		$I->acceptPopup();
+		$I->wait(5);
+
+		// Check that the subscriber is no longer assigned to the tag.
+		$I->apiCheckSubscriberHasNoTags($I, $subscriberID);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds [this requested functionality](https://n7studios-workspace.slack.com/archives/C02KFR6N1GF/p1731601291377549) to remove a tag when a MemberMouse Membership Level or Bundle is removed from a member.

![Screenshot 2024-11-26 at 10 46 13](https://github.com/user-attachments/assets/1907e1b8-91de-427e-8849-c5fdc9f74f35)

## Testing

- `testMemberTagRemovedWhenBundleCancelled`: Test that the subscriber's tag is removed in Kit when their MemberMouse bundle is cancelled.
- `testMemberTagRemovedWhenMembershipLevelCancelled`: Test that the subscriber's tag is removed in Kit when their MemberMouse membership level is cancelled.
- `testMemberTagRemovedWhenDeleted`: Test that the subscriber's tag is removed in Kit when their member account is deleted in MemberMouse.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)