### PR TITLE
Fix Flaky Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,10 +51,14 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ 'latest' ]
-        php-versions: [ '7.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
+          'acceptance/bundle',
+          'acceptance/general',
+          'acceptance/member',
+          'acceptance/member-update',
           'acceptance/product'
         ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,14 +51,10 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ 'latest' ]
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
-          'acceptance/bundle',
-          'acceptance/general',
-          'acceptance/member',
-          'acceptance/member-update',
           'acceptance/product'
         ]
 

--- a/tests/_support/Helper/Acceptance/MemberMouse.php
+++ b/tests/_support/Helper/Acceptance/MemberMouse.php
@@ -202,7 +202,7 @@ class MemberMouse extends \Codeception\Module
 	{
 		// Cancel the user's bundle.
 		$I->amOnAdminPage('admin.php?page=manage_members');
-		$I->click($emailAddress);
+		$I->click('a[title="' . $emailAddress . '"]');
 		$I->click('Access Rights');
 		$I->click('a[title="Cancel ' . $bundleName . '"]');
 

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -49,23 +49,15 @@ class ThirdPartyPlugin extends \Codeception\Module
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
 		// Login as the Administrator.
-		$I->loginAsAdmin();
-
-		/*
-		// This works.
-		// Login as the Administrator.
 		$I->amOnPage('wp-login.php');
         $I->waitForElement('#user_login', 10);
         $I->fillField('#user_login', $_ENV['TEST_SITE_ADMIN_USERNAME']);
         $I->waitForElement('#user_pass', 10);
         $I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
-        $I->wait(1);
-        $I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
         $I->click('#wp-submit');
 
         // Wait for admin interface to load.
         $I->waitForElementVisible('body.wp-admin');
-        */
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -49,6 +49,11 @@ class ThirdPartyPlugin extends \Codeception\Module
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
 		// Login as the Administrator.
+		$I->loginAsAdmin();
+
+		/*
+		// This works.
+		// Login as the Administrator.
 		$I->amOnPage('wp-login.php');
         $I->waitForElement('#user_login', 10);
         $I->fillField('#user_login', $_ENV['TEST_SITE_ADMIN_USERNAME']);
@@ -60,6 +65,7 @@ class ThirdPartyPlugin extends \Codeception\Module
 
         // Wait for admin interface to load.
         $I->waitForElementVisible('body.wp-admin');
+        */
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -49,10 +49,6 @@ class ThirdPartyPlugin extends \Codeception\Module
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
 		// Login as the Administrator.
-		$I->loginAsAdmin();
-
-		/*
-		// Login as the Administrator.
 		$I->amOnPage('wp-login.php');
         $I->waitForElement('#user_login', 10);
         $I->waitForElement('#user_pass', 10);
@@ -60,7 +56,9 @@ class ThirdPartyPlugin extends \Codeception\Module
         $I->fillField('#user_login', $_ENV['TEST_SITE_ADMIN_USERNAME']);
         $I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
         $I->click('#wp-submit');
-        */
+
+        // Wait for admin interface to load.
+        $I->waitForElementVisible('body.wp-admin');
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -48,12 +48,14 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 */
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
-		$I->wait(2);
-
 		// Login as the Administrator.
-		$I->loginAsAdmin();
-
-		$I->see('XXX');
+		$I->amOnPage('wp-login.php');
+        $I->waitForElement('#user_login', 10);
+        $I->waitForElement('#user_pass', 10);
+        $I->waitForElement('#wp-submit', 10);
+        $I->fillField('#user_login', $_ENV['TEST_SITE_ADMIN_USERNAME']);
+        $I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+        $I->see('XXXXX');
 
 		// Wait for the MemberMouse dashboard to load.
 		switch ( $name ) {

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -50,14 +50,14 @@ class ThirdPartyPlugin extends \Codeception\Module
 	{
 		// Login as the Administrator.
 		$I->amOnPage('wp-login.php');
-        $I->waitForElement('#user_login', 10);
-        $I->fillField('#user_login', $_ENV['TEST_SITE_ADMIN_USERNAME']);
-        $I->waitForElement('#user_pass', 10);
-        $I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
-        $I->click('#wp-submit');
+		$I->waitForElement('#user_login', 10);
+		$I->fillField('#user_login', $_ENV['TEST_SITE_ADMIN_USERNAME']);
+		$I->waitForElement('#user_pass', 10);
+		$I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+		$I->click('#wp-submit');
 
-        // Wait for admin interface to load.
-        $I->waitForElementVisible('body.wp-admin');
+		// Wait for admin interface to load.
+		$I->waitForElementVisible('body.wp-admin');
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -49,6 +49,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
 		// Login as the Administrator.
+		$I->loginAsAdmin();
+
+		/*
+		// Login as the Administrator.
 		$I->amOnPage('wp-login.php');
         $I->waitForElement('#user_login', 10);
         $I->waitForElement('#user_pass', 10);
@@ -56,13 +60,7 @@ class ThirdPartyPlugin extends \Codeception\Module
         $I->fillField('#user_login', $_ENV['TEST_SITE_ADMIN_USERNAME']);
         $I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
         $I->click('#wp-submit');
-
-		// Wait for the MemberMouse dashboard to load.
-		switch ( $name ) {
-			case 'membermouse-platform':
-				$I->waitForElementVisible('#mm-view-container');
-				break;
-		}
+        */
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -51,6 +51,8 @@ class ThirdPartyPlugin extends \Codeception\Module
 		// Login as the Administrator.
 		$I->loginAsAdmin();
 
+		$I->see('XXX');
+
 		// Wait for the MemberMouse dashboard to load.
 		switch ( $name ) {
 			case 'membermouse-platform':

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -51,9 +51,10 @@ class ThirdPartyPlugin extends \Codeception\Module
 		// Login as the Administrator.
 		$I->amOnPage('wp-login.php');
         $I->waitForElement('#user_login', 10);
-        $I->waitForElement('#user_pass', 10);
-        $I->waitForElement('#wp-submit', 10);
         $I->fillField('#user_login', $_ENV['TEST_SITE_ADMIN_USERNAME']);
+        $I->waitForElement('#user_pass', 10);
+        $I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+        $I->wait(1);
         $I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
         $I->click('#wp-submit');
 

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -48,6 +48,8 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 */
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
+		$I->wait(2);
+
 		// Login as the Administrator.
 		$I->loginAsAdmin();
 

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -55,7 +55,7 @@ class ThirdPartyPlugin extends \Codeception\Module
         $I->waitForElement('#wp-submit', 10);
         $I->fillField('#user_login', $_ENV['TEST_SITE_ADMIN_USERNAME']);
         $I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
-        $I->see('XXXXX');
+        $I->click('#wp-submit');
 
 		// Wait for the MemberMouse dashboard to load.
 		switch ( $name ) {

--- a/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
+++ b/tests/_support/Helper/Acceptance/ThirdPartyPlugin.php
@@ -54,6 +54,12 @@ class ThirdPartyPlugin extends \Codeception\Module
 		$I->fillField('#user_login', $_ENV['TEST_SITE_ADMIN_USERNAME']);
 		$I->waitForElement('#user_pass', 10);
 		$I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+
+		// Wait and complete the password field again, because sometimes it doesn't
+		// get filled the first time.
+		$I->wait(1);
+		$I->fillField('#user_pass', $_ENV['TEST_SITE_ADMIN_PASSWORD']);
+
 		$I->click('#wp-submit');
 
 		// Wait for admin interface to load.

--- a/tests/acceptance/bundle/BundleTagCest.php
+++ b/tests/acceptance/bundle/BundleTagCest.php
@@ -310,6 +310,7 @@ class BundleTagCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		$I->deactivateThirdPartyPlugin($I, 'membermouse-platform');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/general/SettingsCest.php
+++ b/tests/acceptance/general/SettingsCest.php
@@ -310,6 +310,7 @@ class SettingsCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		$I->deactivateThirdPartyPlugin($I, 'membermouse-platform');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/member-update/MemberSubscribeCest.php
+++ b/tests/acceptance/member-update/MemberSubscribeCest.php
@@ -73,6 +73,7 @@ class MemberSubscribeCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		$I->deactivateThirdPartyPlugin($I, 'membermouse-platform');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/member/MemberTagCest.php
+++ b/tests/acceptance/member/MemberTagCest.php
@@ -497,6 +497,7 @@ class MemberTagCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		$I->deactivateThirdPartyPlugin($I, 'membermouse-platform');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/product/ProductTagCest.php
+++ b/tests/acceptance/product/ProductTagCest.php
@@ -106,6 +106,7 @@ class ProductTagCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		$I->deactivateThirdPartyPlugin($I, 'membermouse-platform');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/product/ProductTagCest.php
+++ b/tests/acceptance/product/ProductTagCest.php
@@ -106,7 +106,6 @@ class ProductTagCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
-		$I->see('XXX');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/product/ProductTagCest.php
+++ b/tests/acceptance/product/ProductTagCest.php
@@ -106,6 +106,7 @@ class ProductTagCest
 	 */
 	public function _passed(AcceptanceTester $I)
 	{
+		$I->see('XXX');
 		$I->deactivateConvertKitPlugin($I);
 		$I->resetConvertKitPlugin($I);
 	}

--- a/tests/acceptance/product/ProductTagCest.php
+++ b/tests/acceptance/product/ProductTagCest.php
@@ -93,6 +93,9 @@ class ProductTagCest
 
 		// Check subscriber does not exist.
 		$subscriberID = $I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
+
+		// Logout.
+		$I->memberMouseLogOut($I);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes flaky tests by:
- using an improved method to log in to WordPress to deactivate Plugins,
- deactivate the MemberMouse Plugin after tests pass (as we do for the Kit Plugin),
- use a better selector when editing a user in MemberMouse

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)