### PR TITLE
Tests: Use PHPStan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         "codeception/util-universalframework": "^1.0",
         "php-webdriver/webdriver": "^1.0",
         "wp-coding-standards/wpcs": "^3.0.0",
-        "phpstan/phpstan": "^1.7",
-        "szepeviktor/phpstan-wordpress": "^1.0",
-        "wp-cli/wp-cli": "2.8.1",
+        "phpstan/phpstan": "^1.0 || ^2.0",
+        "szepeviktor/phpstan-wordpress": "^1.0 || ^2.0",
+        "wp-cli/wp-cli": "2.11",
         "gumlet/php-image-resize": "^1.6"
     },
     "minimum-stability": "dev",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -25,9 +25,6 @@ parameters:
     scanFiles:
         - /home/runner/work/convertkit-membermouse/convertkit-membermouse/wordpress/wp-config.php
 
-    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
-    reportUnmatchedIgnoredErrors: false
-
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,13 @@ parameters:
     scanDirectories:
         - /home/runner/work/convertkit-membermouse/convertkit-membermouse/wordpress/wp-content/plugins
 
+    # Location of constants for PHPStan to scan, building symbols.
+    scanFiles:
+        - /home/runner/work/convertkit-membermouse/convertkit-membermouse/wordpress/wp-config.php
+
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -25,9 +25,6 @@ parameters:
     scanFiles:
         - /home/runner/work/convertkit-membermouse/convertkit-membermouse/wordpress/wp-config.php
 
-    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
-    reportUnmatchedIgnoredErrors: false
-
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -1,4 +1,4 @@
-# PHPStan configuration for local static analysis.
+# PHPStan configuration for GitHub Actions.
 
 # Include PHPStan for WordPress configuration.
 includes:
@@ -9,25 +9,25 @@ parameters:
     # Paths to scan
     # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
     paths:
-        - wp-convertkit.php
+        - convertkit-membermouse.php
         - admin/
         - includes/
 
     # Files that include Plugin-specific PHP constants
     bootstrapFiles:
-        - wp-convertkit.php
+        - convertkit-membermouse.php
 
     # Location of WordPress Plugins for PHPStan to scan, building symbols.
     scanDirectories:
-        - /Users/tim/Local Sites/convertkit-github/app/public/wp-content/plugins
+        - /home/runner/work/convertkit-membermouse/convertkit-membermouse/wordpress/wp-content/plugins
+
+    # Location of constants for PHPStan to scan, building symbols.
+    scanFiles:
+        - /home/runner/work/convertkit-membermouse/convertkit-membermouse/wordpress/wp-config.php
+
+    # Don't report unmatched ignored errors on older PHP versions (7.2, 7.3)
+    reportUnmatchedIgnoredErrors: false
 
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5
-
-    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
-    # so they're false positives.
-    ignoreErrors:
-        - '#Access to an undefined property WP_Theme::#'
-        - '#Constant WP_MEMORY_LIMIT not found.#'
-        - '#Function apply_filters invoked with#' # apply_filters() accepted a variable number of parameters, which PHPStan fails to detect


### PR DESCRIPTION
## Summary

Runs static analysis using the latest [2.0](https://github.com/phpstan/phpstan/blob/2.0.x/UPGRADING.md) version of PHPStan when tests are performed on PHP 7.4 and higher, which is the minimum supported version.

PHPStan 1.x will run on tests using PHP < 7.4.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)