### PR TITLE
Use Kit WordPress Libraries 2.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "2.0.5"
+        "convertkit/convertkit-wordpress-libraries": "2.0.6"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",


### PR DESCRIPTION
## Summary

Uses Kit WordPress Libraries 2.0.6, which includes support for the referrer parameter when subscribing to forms.

While the Kit for MemberMouse Plugin does not utilize the `add_subscriber_to_form` method, keeping the underlying libraries up-to-date is a good practice to ensure compatibility and maintain optimal functionality.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)