### PR TITLE
Use `WordPress` Coding Standards ruleset

### DIFF
--- a/admin/class-convertkit-mm-admin.php
+++ b/admin/class-convertkit-mm-admin.php
@@ -102,7 +102,7 @@ class ConvertKit_MM_Admin {
 		if ( ! array_key_exists( 'page', $_REQUEST ) ) {  // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
-		if ( sanitize_text_field( $_REQUEST['page'] ) !== 'convertkit-mm' ) {  // phpcs:ignore WordPress.Security.NonceVerification
+		if ( sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) !== 'convertkit-mm' ) {  // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 
@@ -112,7 +112,7 @@ class ConvertKit_MM_Admin {
 		}
 
 		// Sanitize token.
-		$authorization_code = sanitize_text_field( $_REQUEST['code'] ); // phpcs:ignore WordPress.Security.NonceVerification
+		$authorization_code = sanitize_text_field( wp_unslash( $_REQUEST['code'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		// Exchange the authorization code and verifier for an access token.
 		$api    = new ConvertKit_MM_API( CONVERTKIT_MM_OAUTH_CLIENT_ID, CONVERTKIT_MM_OAUTH_CLIENT_REDIRECT_URI );
@@ -167,7 +167,7 @@ class ConvertKit_MM_Admin {
 		if ( ! array_key_exists( 'page', $_REQUEST ) ) {  // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
-		if ( sanitize_text_field( $_REQUEST['page'] ) !== 'convertkit-mm' ) {  // phpcs:ignore WordPress.Security.NonceVerification
+		if ( sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) !== 'convertkit-mm' ) {  // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 
@@ -230,7 +230,7 @@ class ConvertKit_MM_Admin {
 		if ( ! array_key_exists( 'page', $_REQUEST ) ) {  // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
-		if ( sanitize_text_field( $_REQUEST['page'] ) !== 'convertkit-mm' ) {  // phpcs:ignore WordPress.Security.NonceVerification
+		if ( sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) !== 'convertkit-mm' ) {  // phpcs:ignore WordPress.Security.NonceVerification
 			return;
 		}
 
@@ -297,7 +297,7 @@ class ConvertKit_MM_Admin {
 		if ( ! array_key_exists( 'page', $_REQUEST ) ) {
 			return false;
 		}
-		if ( sanitize_text_field( $_REQUEST['page'] ) !== 'convertkit-mm' ) {
+		if ( sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) !== 'convertkit-mm' ) {
 			return false;
 		}
 		// phpcs:enable
@@ -1058,7 +1058,7 @@ class ConvertKit_MM_Admin {
 			return $levels;
 		}
 
-		$result = $wpdb->get_results( 'SELECT id, name, status FROM ' . MM_TABLE_MEMBERSHIP_LEVELS, OBJECT ); // phpcs:ignore WordPress.DB.PreparedSQL
+		$result = $wpdb->get_results( 'SELECT id, name, status FROM ' . MM_TABLE_MEMBERSHIP_LEVELS, OBJECT ); // phpcs:ignore WordPress.DB
 
 		foreach ( $result as $_level ) {
 			$levels[ $_level->id ] = $_level->name;
@@ -1084,7 +1084,7 @@ class ConvertKit_MM_Admin {
 			return $products;
 		}
 
-		$result = $wpdb->get_results( 'SELECT id, name FROM ' . MM_TABLE_PRODUCTS, OBJECT ); // phpcs:ignore WordPress.DB.PreparedSQL
+		$result = $wpdb->get_results( 'SELECT id, name FROM ' . MM_TABLE_PRODUCTS, OBJECT ); // phpcs:ignore WordPress.DB
 
 		foreach ( $result as $product ) {
 			$products[ $product->id ] = $product->name;
@@ -1110,7 +1110,7 @@ class ConvertKit_MM_Admin {
 			return $bundles;
 		}
 
-		$result = $wpdb->get_results( 'SELECT id, name FROM ' . MM_TABLE_BUNDLES, OBJECT ); // phpcs:ignore WordPress.DB.PreparedSQL
+		$result = $wpdb->get_results( 'SELECT id, name FROM ' . MM_TABLE_BUNDLES, OBJECT ); // phpcs:ignore WordPress.DB
 
 		foreach ( $result as $bundle ) {
 			$bundles[ $bundle->id ] = $bundle->name;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,8 +10,8 @@
 	<!-- Exclude minified Javascript files. -->
 	<exclude-pattern>*.min.js</exclude-pattern>
 
-	<!-- Check that code meets WordPress-Extra standards. -->
-	<rule ref="WordPress-Extra">
+	<!-- Check that code meets WordPress standards - this includes core, docs and extra. -->
+	<rule ref="WordPress">
 		<!--
 		We may want a middle ground though. The best way to do this is add the
 		entire ruleset, then rule by rule, remove ones that don't suit a project.
@@ -29,12 +29,10 @@
 		<exclude name="WordPress.Security.EscapeOutput"/>
 		-->
 		<exclude name="WordPress.PHP.YodaConditions" />
+		<exclude name="WordPress.DB.SlowDBQuery.slow_db_query_meta_query" />
 		<exclude name="PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose" />
 		<exclude name="PSR2.Classes.ClassDeclaration.CloseBraceAfterBody" />
 	</rule>
-
-	<!-- Check that code is documented to WordPress Standards. -->
-	<rule ref="WordPress-Docs"/>
 
 	<!-- Add in some extra rules from other standards. -->
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>


### PR DESCRIPTION
## Summary

Currently, we implement `WordPress-Docs` and `WordPress-Extra` (which, in turn implements `WordPress-Core`) coding standards.

However, switching this to the complete [`WordPress` ruleset](https://github.com/WordPress/WordPress-Coding-Standards?tab=readme-ov-file#standards-subsets) (which lists itself as comprising of `WordPress-Core`, `WordPress-Docs` and `WordPress-Extra`) introduces some additional rulesets.

This PR updates code to meet these coding standards, primarily covering checking and unslashing superglobals in PHP.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)