### PR TITLE
Remove `load_plugin_textdomain`

### DIFF
--- a/includes/class-convertkit-mm.php
+++ b/includes/class-convertkit-mm.php
@@ -57,9 +57,6 @@ class ConvertKit_MM {
 		// Initialize.
 		add_action( 'init', array( $this, 'init' ) );
 
-		// Load language files.
-		add_action( 'init', array( $this, 'load_language_files' ) );
-
 	}
 
 	/**
@@ -136,20 +133,6 @@ class ConvertKit_MM {
 		 * @since   1.2.0
 		 */
 		do_action( 'convertkit_membermouse_initialize_global' );
-
-	}
-
-	/**
-	 * Loads the plugin's translated strings, if available.
-	 *
-	 * @since   1.2.0
-	 */
-	public function load_language_files() {
-
-		// If the .mo file for a given language is available in WP_LANG_DIR/convertkit-membermouse
-		// i.e. it's available as a translation at https://translate.wordpress.org/projects/wp-plugins/convertkit-membermouse/,
-		// it will be used instead of the .mo file in convertkit-membermouse/languages.
-		load_plugin_textdomain( 'convertkit-mm', false, 'convertkit-membermouse/languages' );
 
 	}
 


### PR DESCRIPTION
## Summary

Removes the call to `load_plugin_textdomain`, as [it's not needed since WordPress 4.6](https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/#Enhanced-support-for-only-using-PHP-translation-files):

> Reminder: if your plugin or theme is hosted on WordPress.org and is still using load_*_textdomain(), you can remove this call. Since WordPress 4.6, plugins and themes no longer need load_plugin_textdomain() or load_theme_textdomain(). WordPress automatically loads the translations for you when needed. If you still support older WordPress versions or do not host your plugin/theme on WordPress.org, move the function call to a later hook such as init.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)