### PR TITLE
Require all Plugin Files

### DIFF
--- a/convertkit-membermouse.php
+++ b/convertkit-membermouse.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'ConvertKit_Log' ) ) {
 	require_once CONVERTKIT_MM_PATH . '/vendor/convertkit/convertkit-wordpress-libraries/src/class-convertkit-log.php';
 }
 
-// Load plugin files that are always required.
+// Load plugin files.
 require CONVERTKIT_MM_PATH . 'includes/class-convertkit-mm-actions.php';
 require CONVERTKIT_MM_PATH . 'includes/class-convertkit-mm-api.php';
 require CONVERTKIT_MM_PATH . 'includes/class-convertkit-mm-resource.php';
@@ -61,11 +61,7 @@ require CONVERTKIT_MM_PATH . 'includes/class-convertkit-mm-resource-tags.php';
 require CONVERTKIT_MM_PATH . 'includes/class-convertkit-mm-settings.php';
 require CONVERTKIT_MM_PATH . 'includes/class-convertkit-mm.php';
 require CONVERTKIT_MM_PATH . 'includes/convertkit-mm-functions.php';
-
-// Load files that are only used in the WordPress Administration interface.
-if ( is_admin() ) {
-	require CONVERTKIT_MM_PATH . 'admin/class-convertkit-mm-admin.php';
-}
+require CONVERTKIT_MM_PATH . 'admin/class-convertkit-mm-admin.php';
 
 /**
  * Main function to return Plugin instance.


### PR DESCRIPTION
## Summary

Loads all Plugin files, as we do for [Kit](https://github.com/Kit/convertkit-wordpress/pull/812) and [WooCommerce](https://github.com/Kit/convertkit-woocommerce/pull/129), to ensure compatibility with third party centralised maintenance Plugins, such as Solid Central (previously iThemes Sync).

## Testing

iThemes Sync is a remote service that connects WordPress sites that are web accessible and have the iThemes Sync plugin installed and authenticated.  It's not possible to write a test, because GitHub Actions spin up WordPress instances that are not web accessible.

Manual testing was performed, to confirm the change resolves.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)