### PR TITLE
Tests: Improve reliability

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
-        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
 
     # Steps to install, configure and run tests
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         wp-versions: [ 'latest' ] #[ 'latest' ]
-        php-versions: [ '8.1', '8.2', '8.3' ] #[ '7.3', '7.4', '8.0', '8.1' ]
+        php-versions: [ '8.1', '8.2', '8.3', '8.4' ] #[ '7.3', '7.4', '8.0', '8.1' ]
         
         # Folder names within the 'tests' folder to run tests in parallel.
         test-groups: [
@@ -129,9 +129,9 @@ jobs:
         run: mv /home/runner/work/convertkit-membermouse/convertkit-membermouse/convertkit-membermouse ${{ env.PLUGIN_DIR }}
 
       # WP_DEBUG = true is required so all PHP errors are output and caught by tests (E_ALL).
-      # WP_DEBUG = false for Member tests, as MemberMouse outputs Xdebug errors in its 'Update Member' screen outside of our control.
+      # WP_DEBUG = false for PHP 8.4, otherwise E_DEPRECATED is output due to MemberMouse.
       - name: Enable WP_DEBUG
-        if: ${{ matrix.test-groups != 'EndToEnd/member-update' }}
+        if: ${{ matrix.test-groups != 'EndToEnd/member-update' && matrix.php-versions != '8.4' }}
         working-directory: ${{ env.ROOT_DIR }}
         run: |
           wp-cli config set WP_DEBUG true --raw

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-        "convertkit/convertkit-wordpress-libraries": "2.0.8"
+        "convertkit/convertkit-wordpress-libraries": "2.0.9"
     },
     "require-dev": {
         "php-webdriver/webdriver": "^1.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://kit.com/
 Tags: convertkit, email, marketing, membermouse
 Requires at least: 5.0
 Tested up to: 6.8
-Requires PHP: 5.6.20
+Requires PHP: 7.1
 Stable tag: 1.3.2
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/tests/Support/Helper/ThirdPartyPlugin.php
+++ b/tests/Support/Helper/ThirdPartyPlugin.php
@@ -114,6 +114,6 @@ class ThirdPartyPlugin extends \Codeception\Module
 		$I->click('#wp-submit');
 
 		// Wait for the Dashboard page to load, to confirm login succeeded.
-		$I->waitForElementVisible('body.index-php');
+		$I->waitForElementVisible('body.wp-admin');
 	}
 }

--- a/tests/Support/Helper/ThirdPartyPlugin.php
+++ b/tests/Support/Helper/ThirdPartyPlugin.php
@@ -20,18 +20,22 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 */
 	public function activateThirdPartyPlugin($I, $name)
 	{
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $this->amLoggedInAsAdmin($I) ) {
+			$this->doLoginAsAdmin($I);
+		}
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
+		// Wait for the Plugins page to load.
+		$I->waitForElementVisible('body.plugins-php');
+
 		// Activate the Plugin.
 		$I->activatePlugin($name);
 
-		// Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
-		// causing seePluginActivated() to fail.
-		$I->amOnPluginsPage();
+		// Wait for the Plugins page to load with the Plugin activated, to confirm it activated.
+		$I->waitForElementVisible('table.plugins tr[data-slug=' . $name . '].active');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -48,33 +52,68 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 */
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
-		// Login as the Administrator.
-		$I->amOnPage('wp-login.php');
-		$I->waitForElement('#user_login', 10);
-		$I->fillField('#user_login', $_ENV['WORDPRESS_ADMIN_USER']);
-		$I->waitForElement('#user_pass', 10);
-		$I->fillField('#user_pass', $_ENV['WORDPRESS_ADMIN_PASSWORD']);
-
-		// Wait and complete the password field again, because sometimes it doesn't
-		// get filled the first time.
-		$I->wait(1);
-		$I->fillField('#user_pass', $_ENV['WORDPRESS_ADMIN_PASSWORD']);
-
-		$I->click('#wp-submit');
-
-		// Wait for admin interface to load.
-		$I->waitForElementVisible('body.wp-admin');
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $this->amLoggedInAsAdmin($I) ) {
+			$this->doLoginAsAdmin($I);
+		}
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
+		// Wait for the Plugins page to load.
+		$I->waitForElementVisible('body.plugins-php');
+
 		// Deactivate the Plugin.
 		$I->deactivatePlugin($name);
+	}
 
-		// Wait for notice to display.
-		$I->waitForElementVisible('div.updated');
+	/**
+	 * Helper method to check if the Administrator is logged in.
+	 *
+	 * @since   1.3.6
+	 *
+	 * @param   EndToEndTester $I      EndToEnd Tester.
+	 *
+	 * @return  bool
+	 */
+	public function amLoggedInAsAdmin($I)
+	{
+		$cookies = $I->grabCookiesWithPattern('/^wordpress_logged_in_[a-z0-9]{32}$/');
+		return ! is_null( $cookies );
+	}
 
-		// Check that the Plugin deactivated successfully.
-		$I->seePluginDeactivated($name);
+	/**
+	 * Helper method to reliably login as the Administrator.
+	 *
+	 * @since   1.3.6
+	 *
+	 * @param   EndToEndTester $I      EndToEnd Tester.
+	 */
+	public function doLoginAsAdmin($I)
+	{
+		// Add admin_email_lifespan option to prevent Administration email verification screen from
+		// displaying on login, which causes tests to fail.
+		// This is included in the dump.sql file, but seems to be deleted after a test.
+		$I->haveOptionInDatabase('admin_email_lifespan', '1805512805');
+
+		// Load login screen.
+		$I->amOnPage('wp-login.php');
+
+		// Wait for the login form to load.
+		$I->waitForElementVisible('#user_login');
+		$I->waitForElementVisible('#user_pass');
+		$I->waitForElementVisible('#wp-submit');
+
+		// Fill in the login form.
+		$I->click('#user_login');
+		$I->fillField('#user_login', $_ENV['WORDPRESS_ADMIN_USER']);
+		$I->click('#user_pass');
+		$I->fillField('#user_pass', $_ENV['WORDPRESS_ADMIN_PASSWORD']);
+
+		// Submit.
+		$I->click('#wp-submit');
+
+		// Wait for the Dashboard page to load, to confirm login succeeded.
+		$I->waitForElementVisible('body.index-php');
 	}
 }


### PR DESCRIPTION
## Summary

Improve reliability of tests by adding the `amLoggedInAsAdmin` and `doLoginAsAdmin` helper methods, as used in the other Kit Plugins.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)