### PR TITLE
Tests: Use Named Arguments

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -114,6 +114,7 @@ jobs:
       # Run Coding Standards on Tests.
       - name: Run Coding Standards on Tests
         working-directory: ${{ env.PLUGIN_DIR }}
+        if: ${{ matrix.php-versions == '8.1' || matrix.php-versions == '8.2' || matrix.php-versions == '8.3' || matrix.php-versions == '8.4' }}
         run: php vendor/bin/phpcs -q --standard=phpcs.tests.xml --report=checkstyle ./tests | cs2pr
 
       # Run WordPress Coding Standards on Plugin.

--- a/tests/EndToEnd/bundle/BundleCustomFieldsCest.php
+++ b/tests/EndToEnd/bundle/BundleCustomFieldsCest.php
@@ -38,10 +38,18 @@ class BundleCustomFieldsCest
 	public function testMemberCustomFieldsWhenBundleAdded(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Create bundle.
-		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+		$bundleID = $I->memberMouseCreateBundle(
+			$I,
+			name: 'Bundle',
+			productIDs: [ $productID ]
+		);
 
 		// Setup Plugin to tag users purchasing the bundle to the
 		// Kit Tag ID, and store the Last Name in the Kit
@@ -61,19 +69,27 @@ class BundleCustomFieldsCest
 		$I->memberMouseLogOut($I);
 
 		// Complete checkout.
-		$I->memberMouseCheckoutProduct($I, $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'], $emailAddress);
+		$I->memberMouseCheckoutProduct(
+			$I,
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'],
+			emailAddress: $emailAddress
+		);
 
 		// Check subscriber exists.
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Check that the subscriber has the custom field data.
 		$I->apiCustomFieldDataIsValid(
 			$I,
-			$subscriber,
-			[
+			subscriber: $subscriber,
+			customFields: [
 				'last_name' => 'Last',
 			]
 		);
@@ -90,10 +106,18 @@ class BundleCustomFieldsCest
 	public function testMemberCustomFieldsWhenBundleReactivated(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Create bundle.
-		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+		$bundleID = $I->memberMouseCreateBundle(
+			$I,
+			name: 'Bundle',
+			productIDs: [ $productID ]
+		);
 
 		// Generate email address for test.
 		$emailAddress = $I->generateEmailAddress();
@@ -105,13 +129,21 @@ class BundleCustomFieldsCest
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 
 		// Assign bundle.
-		$I->memberMouseAssignBundleToMember($I, $emailAddress, 'Bundle');
+		$I->memberMouseAssignBundleToMember(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check that the subscriber does not exist, as no tagging took place.
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 
 		// Cancel the user's bundle.
-		$I->memberMouseCancelMemberBundle($I, $emailAddress, 'Bundle');
+		$I->memberMouseCancelMemberBundle(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check that the subscriber does not exist, as no tagging took place.
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
@@ -128,19 +160,27 @@ class BundleCustomFieldsCest
 		);
 
 		// Re-activate the user's bundle.
-		$I->memberMouseResumeMemberBundle($I, $emailAddress, 'Bundle');
+		$I->memberMouseResumeMemberBundle(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check subscriber exists.
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the bundle's tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Check that the subscriber has the custom field data.
 		$I->apiCustomFieldDataIsValid(
 			$I,
-			$subscriber,
-			[
+			subscriber: $subscriber,
+			customFields: [
 				'last_name' => 'Last',
 			]
 		);

--- a/tests/EndToEnd/bundle/BundleTagCest.php
+++ b/tests/EndToEnd/bundle/BundleTagCest.php
@@ -38,10 +38,18 @@ class BundleTagCest
 	public function testMemberTaggedWhenBundleAdded(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Create bundle.
-		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+		$bundleID = $I->memberMouseCreateBundle(
+			$I,
+			name: 'Bundle',
+			productIDs: [ $productID ]
+		);
 
 		// Setup Plugin to tag users purchasing the bundle to the
 		// ConvertKit Tag ID.
@@ -59,13 +67,21 @@ class BundleTagCest
 		$I->memberMouseLogOut($I);
 
 		// Complete checkout.
-		$I->memberMouseCheckoutProduct($I, $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'], $emailAddress);
+		$I->memberMouseCheckoutProduct(
+			$I,
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'],
+			emailAddress: $emailAddress
+		);
 
 		// Check subscriber exists.
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -80,10 +96,18 @@ class BundleTagCest
 	public function testMemberTaggedWhenBundleReactivated(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Create bundle.
-		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+		$bundleID = $I->memberMouseCreateBundle(
+			$I,
+			name: 'Bundle',
+			productIDs: [ $productID ]
+		);
 
 		// Generate email address for test.
 		$emailAddress = $I->generateEmailAddress();
@@ -95,13 +119,21 @@ class BundleTagCest
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 
 		// Assign bundle.
-		$I->memberMouseAssignBundleToMember($I, $emailAddress, 'Bundle');
+		$I->memberMouseAssignBundleToMember(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check that the subscriber does not exist, as no tagging took place.
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 
 		// Cancel the user's bundle.
-		$I->memberMouseCancelMemberBundle($I, $emailAddress, 'Bundle');
+		$I->memberMouseCancelMemberBundle(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check that the subscriber does not exist, as no tagging took place.
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
@@ -115,13 +147,21 @@ class BundleTagCest
 		);
 
 		// Re-activate the user's bundle.
-		$I->memberMouseResumeMemberBundle($I, $emailAddress, 'Bundle');
+		$I->memberMouseResumeMemberBundle(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check subscriber exists.
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the bundle's tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -135,10 +175,18 @@ class BundleTagCest
 	public function testMemberTaggedWhenBundleCancelled(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Create bundle.
-		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+		$bundleID = $I->memberMouseCreateBundle(
+			$I,
+			name: 'Bundle',
+			productIDs: [ $productID ]
+		);
 
 		// Setup Plugin to tag users when the bundle is cancelled.
 		$I->setupConvertKitPlugin(
@@ -158,19 +206,31 @@ class BundleTagCest
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 
 		// Assign bundle.
-		$I->memberMouseAssignBundleToMember($I, $emailAddress, 'Bundle');
+		$I->memberMouseAssignBundleToMember(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check that the subscriber does not exist, as no tagging took place.
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 
 		// Cancel the user's bundle.
-		$I->memberMouseCancelMemberBundle($I, $emailAddress, 'Bundle');
+		$I->memberMouseCancelMemberBundle(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check subscriber exists.
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the cancelled tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']
+		);
 	}
 
 	/**
@@ -183,10 +243,18 @@ class BundleTagCest
 	public function testMemberTagRemovedWhenBundleCancelled(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Create bundle.
-		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+		$bundleID = $I->memberMouseCreateBundle(
+			$I,
+			name: 'Bundle',
+			productIDs: [ $productID ]
+		);
 
 		// Setup Plugin to tag users purchasing the bundle to the
 		// ConvertKit Tag ID.
@@ -205,7 +273,11 @@ class BundleTagCest
 		$I->memberMouseCreateMember($I, $emailAddress);
 
 		// Assign bundle.
-		$I->memberMouseAssignBundleToMember($I, $emailAddress, 'Bundle');
+		$I->memberMouseAssignBundleToMember(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check subscriber exists.
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
@@ -214,7 +286,11 @@ class BundleTagCest
 		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
 
 		// Cancel the user's bundle.
-		$I->memberMouseCancelMemberBundle($I, $emailAddress, 'Bundle');
+		$I->memberMouseCancelMemberBundle(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check that the subscriber is no longer assigned to the tag.
 		$I->apiCheckSubscriberHasNoTags($I, $subscriber['id']);
@@ -231,10 +307,18 @@ class BundleTagCest
 	public function testMemberNotTaggedWhenBundleAdded(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Create bundle.
-		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+		$bundleID = $I->memberMouseCreateBundle(
+			$I,
+			name: 'Bundle',
+			productIDs: [ $productID ]
+		);
 
 		// Setup Plugin to not tag users purchasing the bundle to the
 		// ConvertKit Tag ID.
@@ -252,7 +336,11 @@ class BundleTagCest
 		$I->memberMouseLogOut($I);
 
 		// Complete checkout.
-		$I->memberMouseCheckoutProduct($I, $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'], $emailAddress);
+		$I->memberMouseCheckoutProduct(
+			$I,
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'],
+			emailAddress: $emailAddress
+		);
 
 		// Check subscriber does not exist.
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
@@ -269,10 +357,18 @@ class BundleTagCest
 	public function testMemberNotTaggedWhenBundleReactivated(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Create bundle.
-		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+		$bundleID = $I->memberMouseCreateBundle(
+			$I,
+			name: 'Bundle',
+			productIDs: [ $productID ]
+		);
 
 		// Generate email address for test.
 		$emailAddress = $I->generateEmailAddress();
@@ -284,19 +380,31 @@ class BundleTagCest
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 
 		// Assign bundle.
-		$I->memberMouseAssignBundleToMember($I, $emailAddress, 'Bundle');
+		$I->memberMouseAssignBundleToMember(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check that the subscriber does not exist, as no tagging took place.
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 
 		// Cancel the user's bundle.
-		$I->memberMouseCancelMemberBundle($I, $emailAddress, 'Bundle');
+		$I->memberMouseCancelMemberBundle(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check that the subscriber does not exist, as no tagging took place.
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
 
 		// Re-activate the user's bundle.
-		$I->memberMouseResumeMemberBundle($I, $emailAddress, 'Bundle');
+		$I->memberMouseResumeMemberBundle(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check that the subscriber does not exist, as no tagging took place.
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);
@@ -313,10 +421,18 @@ class BundleTagCest
 	public function testMemberNotTaggedWhenBundleCancelled(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Create bundle.
-		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+		$bundleID = $I->memberMouseCreateBundle(
+			$I,
+			name: 'Bundle',
+			productIDs: [ $productID ]
+		);
 
 		// Setup Plugin to tag users purchasing the bundle to the
 		// ConvertKit Tag ID.
@@ -335,20 +451,40 @@ class BundleTagCest
 		$I->memberMouseCreateMember($I, $emailAddress);
 
 		// Assign bundle.
-		$I->memberMouseAssignBundleToMember($I, $emailAddress, 'Bundle');
+		$I->memberMouseAssignBundleToMember(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check subscriber exists.
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber was tagged.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Cancel the user's bundle.
-		$I->memberMouseCancelMemberBundle($I, $emailAddress, 'Bundle');
+		$I->memberMouseCancelMemberBundle(
+			$I,
+			emailAddress: $emailAddress,
+			bundleName: 'Bundle'
+		);
 
 		// Check that the subscriber is still assigned to the first tag and has no additional tags.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
-		$I->apiCheckSubscriberTagCount($I, $subscriber['id'], 1);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
+		$I->apiCheckSubscriberTagCount(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagCount: 1
+		);
 	}
 
 	/**

--- a/tests/EndToEnd/bundle/BundleTagCest.php
+++ b/tests/EndToEnd/bundle/BundleTagCest.php
@@ -483,7 +483,7 @@ class BundleTagCest
 		$I->apiCheckSubscriberTagCount(
 			$I,
 			subscriberID: $subscriber['id'],
-			tagCount: 1
+			numberOfTags: 1
 		);
 	}
 

--- a/tests/EndToEnd/general/SettingsCest.php
+++ b/tests/EndToEnd/general/SettingsCest.php
@@ -259,7 +259,11 @@ class SettingsCest
 	public function testSaveProductTagAssignment(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Setup Plugin.
 		$I->setupConvertKitPlugin($I);
@@ -305,10 +309,18 @@ class SettingsCest
 	public function testSaveBundleTagAssignment(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			$I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Create bundle.
-		$bundleID = $I->memberMouseCreateBundle($I, 'Bundle', [ $productID ]);
+		$bundleID = $I->memberMouseCreateBundle(
+			$I,
+			name: 'Bundle',
+			productIDs: [ $productID ]
+		);
 
 		// Setup Plugin.
 		$I->setupConvertKitPlugin($I);

--- a/tests/EndToEnd/member-update/MemberSubscribeCest.php
+++ b/tests/EndToEnd/member-update/MemberSubscribeCest.php
@@ -61,7 +61,7 @@ class MemberSubscribeCest
 		$newLastName     = 'New Last Name';
 		$newEmailAddress = 'new-' . $emailAddress;
 		$I->memberMouseUpdateMember(
-			I: $I,
+			$I,
 			emailAddress: $emailAddress,
 			newEmailAddress: $newEmailAddress,
 			newFirstName: $newFirstName,
@@ -70,7 +70,7 @@ class MemberSubscribeCest
 
 		// Check the subscriber's email address was updated in ConvertKit.
 		$subscriberAfterNewEmailAddress = $I->apiCheckSubscriberExists(
-			I: $I,
+			$I,
 			emailAddress: $newEmailAddress,
 			firstName: $newFirstName
 		);
@@ -80,7 +80,7 @@ class MemberSubscribeCest
 
 		// Check that the subscriber has the custom field data.
 		$I->apiCustomFieldDataIsValid(
-			I: $I,
+			$I,
 			subscriber: $subscriberAfterNewEmailAddress,
 			customFields: [
 				'last_name' => $newLastName,

--- a/tests/EndToEnd/member-update/MemberSubscribeCest.php
+++ b/tests/EndToEnd/member-update/MemberSubscribeCest.php
@@ -60,19 +60,29 @@ class MemberSubscribeCest
 		$newFirstName    = 'New First Name';
 		$newLastName     = 'New Last Name';
 		$newEmailAddress = 'new-' . $emailAddress;
-		$I->memberMouseUpdateMember($I, $emailAddress, $newEmailAddress, $newFirstName, $newLastName);
+		$I->memberMouseUpdateMember(
+			I: $I,
+			emailAddress: $emailAddress,
+			newEmailAddress: $newEmailAddress,
+			newFirstName: $newFirstName,
+			newLastName: $newLastName
+		);
 
 		// Check the subscriber's email address was updated in ConvertKit.
-		$subscriberAfterNewEmailAddress = $I->apiCheckSubscriberExists($I, $newEmailAddress, $newFirstName);
+		$subscriberAfterNewEmailAddress = $I->apiCheckSubscriberExists(
+			I: $I,
+			emailAddress: $newEmailAddress,
+			firstName: $newFirstName
+		);
 
 		// Confirm the subscriber ID is the same.
 		$I->assertEquals($subscriber['id'], $subscriberAfterNewEmailAddress['id']);
 
 		// Check that the subscriber has the custom field data.
 		$I->apiCustomFieldDataIsValid(
-			$I,
-			$subscriberAfterNewEmailAddress,
-			[
+			I: $I,
+			subscriber: $subscriberAfterNewEmailAddress,
+			customFields: [
 				'last_name' => $newLastName,
 			]
 		);

--- a/tests/EndToEnd/member/MemberCustomFieldsCest.php
+++ b/tests/EndToEnd/member/MemberCustomFieldsCest.php
@@ -58,13 +58,17 @@ class MemberCustomFieldsCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Check that the subscriber has the custom field data.
 		$I->apiCustomFieldDataIsValid(
 			$I,
-			$subscriber,
-			[
+			subscriber: $subscriber,
+			customFields: [
 				'last_name' => 'Last',
 			]
 		);
@@ -114,13 +118,17 @@ class MemberCustomFieldsCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			$I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Check that the subscriber has the custom field data.
 		$I->apiCustomFieldDataIsValid(
 			$I,
-			$subscriber,
-			[
+			subscriber: $subscriber,
+			customFields: [
 				'last_name' => 'Last',
 			]
 		);

--- a/tests/EndToEnd/member/MemberTagCest.php
+++ b/tests/EndToEnd/member/MemberTagCest.php
@@ -57,7 +57,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -106,7 +106,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -144,7 +144,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -160,7 +160,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the cancelled tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']
 		);
@@ -197,7 +197,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -247,7 +247,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -262,7 +262,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the cancelled tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']
 		);
@@ -299,7 +299,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -311,7 +311,7 @@ class MemberTagCest
 
 		// Accept popups.
 		$I->memberMouseAcceptPopups(
-			I: $I,
+			$I,
 			numberOfPopups: 2
 		);
 
@@ -357,7 +357,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -376,19 +376,19 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the cancelled tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']
 		);
 
 		// Remove tags added to subscriber.
 		$I->apiSubscriberRemoveTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
 		$I->apiSubscriberRemoveTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']
 		);
@@ -407,7 +407,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag for the second membership level.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -477,7 +477,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -491,7 +491,7 @@ class MemberTagCest
 
 		// Accept popups.
 		$I->memberMouseAcceptPopups(
-			I: $I,
+			$I,
 			numberOfPopups: 2
 		);
 
@@ -500,12 +500,12 @@ class MemberTagCest
 
 		// Check that the subscriber is still assigned to the first tag and has no additional tags.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
 		$I->apiCheckSubscriberTagCount(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			numberOfTags: 1
 		);
@@ -543,7 +543,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -559,12 +559,12 @@ class MemberTagCest
 
 		// Check that the subscriber is still assigned to the first tag and has no additional tags.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
 		$I->apiCheckSubscriberTagCount(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			numberOfTags: 1
 		);
@@ -603,7 +603,7 @@ class MemberTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -618,12 +618,12 @@ class MemberTagCest
 
 		// Check that the subscriber is still assigned to the first tag and has no additional tags.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
 		$I->apiCheckSubscriberTagCount(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			numberOfTags: 1
 		);

--- a/tests/EndToEnd/member/MemberTagCest.php
+++ b/tests/EndToEnd/member/MemberTagCest.php
@@ -56,7 +56,11 @@ class MemberTagCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -101,7 +105,11 @@ class MemberTagCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -135,7 +143,11 @@ class MemberTagCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Cancel the user's membership level.
 		$I->amOnAdminPage('admin.php?page=manage_members');
@@ -147,7 +159,11 @@ class MemberTagCest
 		$I->memberMouseAcceptPopups($I, 2);
 
 		// Check that the subscriber has been assigned to the cancelled tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']
+		);
 	}
 
 	/**
@@ -180,7 +196,11 @@ class MemberTagCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Cancel the user's membership level.
 		$I->amOnAdminPage('admin.php?page=manage_members');
@@ -213,7 +233,6 @@ class MemberTagCest
 			[
 				'convertkit-mapping-1'        => $_ENV['CONVERTKIT_API_TAG_ID'],
 				'convertkit-mapping-1-cancel' => $_ENV['CONVERTKIT_API_TAG_CANCEL_ID'],
-
 			]
 		);
 
@@ -227,7 +246,11 @@ class MemberTagCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Cancel the user's membership level.
 		$I->amOnAdminPage('admin.php?page=manage_members');
@@ -238,7 +261,11 @@ class MemberTagCest
 		$I->memberMouseAcceptPopups($I, 2);
 
 		// Check that the subscriber has been assigned to the cancelled tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']
+		);
 	}
 
 	/**
@@ -271,7 +298,11 @@ class MemberTagCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Cancel the user's membership level.
 		$I->amOnAdminPage('admin.php?page=manage_members');
@@ -279,7 +310,10 @@ class MemberTagCest
 		$I->click('Delete Member');
 
 		// Accept popups.
-		$I->memberMouseAcceptPopups($I, 2);
+		$I->memberMouseAcceptPopups(
+			I: $I,
+			numberOfPopups: 2
+		);
 
 		// Check that the subscriber is no longer assigned to the tag.
 		$I->apiCheckSubscriberHasNoTags($I, $subscriber['id']);
@@ -322,7 +356,11 @@ class MemberTagCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Cancel the user's membership level.
 		$I->amOnAdminPage('admin.php?page=manage_members');
@@ -331,15 +369,29 @@ class MemberTagCest
 		$I->click('Cancel Membership');
 
 		// Accept popups.
-		$I->memberMouseAcceptPopups($I, 2);
+		$I->memberMouseAcceptPopups(
+			$I,
+			numberOfPopups: 2
+		);
 
 		// Check that the subscriber has been assigned to the cancelled tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']
+		);
 
 		// Remove tags added to subscriber.
-		$I->apiSubscriberRemoveTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
-		$I->apiSubscriberRemoveTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']);
-
+		$I->apiSubscriberRemoveTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
+		$I->apiSubscriberRemoveTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_CANCEL_ID']
+		);
 		// Confirm tag removal worked.
 		$I->apiCheckSubscriberHasNoTags($I, $subscriber['id']);
 
@@ -348,10 +400,17 @@ class MemberTagCest
 		$I->click('Change Membership');
 
 		// Accept popups.
-		$I->memberMouseAcceptPopups($I, 2);
+		$I->memberMouseAcceptPopups(
+			$I,
+			numberOfPopups: 2
+		);
 
 		// Check that the subscriber has been assigned to the tag for the second membership level.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -417,7 +476,11 @@ class MemberTagCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Change the user's membership level.
 		$I->amOnAdminPage('admin.php?page=manage_members');
@@ -427,14 +490,25 @@ class MemberTagCest
 		$I->click('Change Membership');
 
 		// Accept popups.
-		$I->memberMouseAcceptPopups($I, 2);
+		$I->memberMouseAcceptPopups(
+			I: $I,
+			numberOfPopups: 2
+		);
 
 		// Check subscriber exists.
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber is still assigned to the first tag and has no additional tags.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
-		$I->apiCheckSubscriberTagCount($I, $subscriber['id'], 1);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
+		$I->apiCheckSubscriberTagCount(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			numberOfTags: 1
+		);
 	}
 
 	/**
@@ -455,7 +529,6 @@ class MemberTagCest
 			[
 				'convertkit-mapping-1'        => $_ENV['CONVERTKIT_API_TAG_ID'],
 				'convertkit-mapping-1-cancel' => '',
-
 			]
 		);
 
@@ -469,7 +542,11 @@ class MemberTagCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Cancel the user's membership level.
 		$I->amOnAdminPage('admin.php?page=manage_members');
@@ -481,8 +558,16 @@ class MemberTagCest
 		$I->memberMouseAcceptPopups($I, 2);
 
 		// Check that the subscriber is still assigned to the first tag and has no additional tags.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
-		$I->apiCheckSubscriberTagCount($I, $subscriber['id'], 1);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
+		$I->apiCheckSubscriberTagCount(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			numberOfTags: 1
+		);
 	}
 
 	/**
@@ -517,7 +602,11 @@ class MemberTagCest
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Cancel the user's membership level.
 		$I->amOnAdminPage('admin.php?page=manage_members');
@@ -528,8 +617,16 @@ class MemberTagCest
 		$I->memberMouseAcceptPopups($I, 2);
 
 		// Check that the subscriber is still assigned to the first tag and has no additional tags.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
-		$I->apiCheckSubscriberTagCount($I, $subscriber['id'], 1);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
+		$I->apiCheckSubscriberTagCount(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			numberOfTags: 1
+		);
 	}
 
 	/**

--- a/tests/EndToEnd/product/ProductCustomFieldsCest.php
+++ b/tests/EndToEnd/product/ProductCustomFieldsCest.php
@@ -39,7 +39,7 @@ class ProductCustomFieldsCest
 	{
 		// Create a product.
 		$productID = $I->memberMouseCreateProduct(
-			I: $I,
+			$I,
 			name: 'Product',
 			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
 		);
@@ -63,7 +63,7 @@ class ProductCustomFieldsCest
 
 		// Complete checkout.
 		$I->memberMouseCheckoutProduct(
-			I: $I,
+			$I,
 			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'],
 			emailAddress: $emailAddress
 		);
@@ -73,14 +73,14 @@ class ProductCustomFieldsCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
 
 		// Check that the subscriber has the custom field data.
 		$I->apiCustomFieldDataIsValid(
-			I: $I,
+			$I,
 			subscriber: $subscriber,
 			customFields: [
 				'last_name' => 'Last',

--- a/tests/EndToEnd/product/ProductCustomFieldsCest.php
+++ b/tests/EndToEnd/product/ProductCustomFieldsCest.php
@@ -38,7 +38,11 @@ class ProductCustomFieldsCest
 	public function testMemberCustomFieldsWhenProductPurchased(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			I: $I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Setup Plugin to tag users purchasing the bundle to the
 		// Kit Tag ID, and store the Last Name in the Kit
@@ -58,19 +62,27 @@ class ProductCustomFieldsCest
 		$I->memberMouseLogOut($I);
 
 		// Complete checkout.
-		$I->memberMouseCheckoutProduct($I, $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'], $emailAddress);
+		$I->memberMouseCheckoutProduct(
+			I: $I,
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'],
+			emailAddress: $emailAddress
+		);
 
 		// Check subscriber exists.
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 
 		// Check that the subscriber has the custom field data.
 		$I->apiCustomFieldDataIsValid(
-			$I,
-			$subscriber,
-			[
+			I: $I,
+			subscriber: $subscriber,
+			customFields: [
 				'last_name' => 'Last',
 			]
 		);

--- a/tests/EndToEnd/product/ProductTagCest.php
+++ b/tests/EndToEnd/product/ProductTagCest.php
@@ -39,7 +39,7 @@ class ProductTagCest
 	{
 		// Create a product.
 		$productID = $I->memberMouseCreateProduct(
-			I: $I,
+			$I,
 			name: 'Product',
 			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
 		);
@@ -61,7 +61,7 @@ class ProductTagCest
 
 		// Complete checkout.
 		$I->memberMouseCheckoutProduct(
-			I: $I,
+			$I,
 			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'],
 			emailAddress: $emailAddress
 		);
@@ -71,7 +71,7 @@ class ProductTagCest
 
 		// Check that the subscriber has been assigned to the tag.
 		$I->apiCheckSubscriberHasTag(
-			I: $I,
+			$I,
 			subscriberID: $subscriber['id'],
 			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
 		);
@@ -89,7 +89,7 @@ class ProductTagCest
 	{
 		// Create a product.
 		$productID = $I->memberMouseCreateProduct(
-			I: $I,
+			$I,
 			name: 'Product',
 			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
 		);
@@ -111,7 +111,7 @@ class ProductTagCest
 
 		// Complete checkout.
 		$I->memberMouseCheckoutProduct(
-			I: $I,
+			$I,
 			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'],
 			emailAddress: $emailAddress
 		);

--- a/tests/EndToEnd/product/ProductTagCest.php
+++ b/tests/EndToEnd/product/ProductTagCest.php
@@ -38,7 +38,11 @@ class ProductTagCest
 	public function testMemberTaggedWhenProductPurchased(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			I: $I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Setup Plugin to tag users purchasing the product to the
 		// ConvertKit Tag ID.
@@ -56,13 +60,21 @@ class ProductTagCest
 		$I->memberMouseLogOut($I);
 
 		// Complete checkout.
-		$I->memberMouseCheckoutProduct($I, $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'], $emailAddress);
+		$I->memberMouseCheckoutProduct(
+			I: $I,
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'],
+			emailAddress: $emailAddress
+		);
 
 		// Check subscriber exists.
 		$subscriber = $I->apiCheckSubscriberExists($I, $emailAddress);
 
 		// Check that the subscriber has been assigned to the tag.
-		$I->apiCheckSubscriberHasTag($I, $subscriber['id'], $_ENV['CONVERTKIT_API_TAG_ID']);
+		$I->apiCheckSubscriberHasTag(
+			I: $I,
+			subscriberID: $subscriber['id'],
+			tagID: $_ENV['CONVERTKIT_API_TAG_ID']
+		);
 	}
 
 	/**
@@ -76,7 +88,11 @@ class ProductTagCest
 	public function testMemberNotTaggedWhenProductPurchased(EndToEndTester $I)
 	{
 		// Create a product.
-		$productID = $I->memberMouseCreateProduct($I, 'Product', $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']);
+		$productID = $I->memberMouseCreateProduct(
+			I: $I,
+			name: 'Product',
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY']
+		);
 
 		// Setup Plugin to not tag users purchasing the product to the
 		// ConvertKit Tag ID.
@@ -94,7 +110,11 @@ class ProductTagCest
 		$I->memberMouseLogOut($I);
 
 		// Complete checkout.
-		$I->memberMouseCheckoutProduct($I, $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'], $emailAddress);
+		$I->memberMouseCheckoutProduct(
+			I: $I,
+			key: $_ENV['MEMBERMOUSE_PRODUCT_REFERENCE_KEY'],
+			emailAddress: $emailAddress
+		);
 
 		// Check subscriber does not exist.
 		$I->apiCheckSubscriberDoesNotExist($I, $emailAddress);

--- a/tests/Support/Helper/MemberMouse.php
+++ b/tests/Support/Helper/MemberMouse.php
@@ -286,13 +286,13 @@ class MemberMouse extends \Codeception\Module
 	 * @since   1.2.0
 	 *
 	 * @param   EndToEndTester $I             Tester.
-	 * @param   string         $productReferenceKey   Product reference key.
-	 * @param   string         $emailAddress          Email Address.
+	 * @param   string         $key           Product reference key.
+	 * @param   string         $emailAddress  Email Address.
 	 */
-	public function memberMouseCheckoutProduct($I, $productReferenceKey, $emailAddress)
+	public function memberMouseCheckoutProduct($I, $key, $emailAddress)
 	{
 		// Navigate to purchase screen for the product.
-		$I->amOnPage('checkout/?rid=' . $productReferenceKey);
+		$I->amOnPage('checkout/?rid=' . $key);
 
 		// Complete checkout.
 		$I->fillField('mm_field_first_name', 'First');


### PR DESCRIPTION
## Summary

Uses named arguments in Tests, as they run on PHP 8.1 and higher, which supports this.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)