### PR TITLE
Composer: Add Commands

### DIFF
--- a/.scripts/build.sh
+++ b/.scripts/build.sh
@@ -1,9 +1,0 @@
-# Build ACTIONS-FILTERS.md
-php create-actions-filters-docs.php
-
-# Generate .pot file
-php -n $(which wp) i18n make-pot ../ ../languages/convertkit-mm.pot
-
-# Build ZIP file
-rm ../convertkit-membermouse.zip
-cd .. && zip -r convertkit-membermouse.zip . -x "*.git*" -x ".scripts/*" -x ".wordpress-org/*" -x "tests/*" -x "vendor/*" -x "*.distignore" -x "*.env.*" -x "*codeception.*" -x "composer.json" -x "composer.lock" -x "*.md" -x "log.txt" -x "phpcs.xml" -x "phpstan.neon" -x "phpstan.neon.dist" -x "phpstan.neon.example" -x "*.DS_Store"

--- a/.scripts/create-plugin-zip.sh
+++ b/.scripts/create-plugin-zip.sh
@@ -1,0 +1,36 @@
+# Remove vendor directory
+cd ..
+rm -rf vendor
+
+# Run composer to only install non-dev dependencies
+composer install --no-dev
+
+# Build ZIP file, excluding non-Plugin files
+[ -e convertkit-membermouse.zip ] && rm convertkit-membermouse.zip
+zip -r convertkit-membermouse.zip . \
+-x "*.git*" \
+-x ".devcontainer/*" \
+-x ".scripts/*" \
+-x ".wordpress-org/*" \
+-x "log/*" \
+-x "tests/*" \
+-x "vendor/composer/*" \
+-x "vendor/convertkit/convertkit-wordpress-libraries/.github" \
+-x "vendor/convertkit/convertkit-wordpress-libraries/tests/*" \
+-x "vendor/convertkit/convertkit-wordpress-libraries/composer.json" \
+-x "vendor/autoload.php" \
+-x "*.distignore" \
+-x "*.env.*" \
+-x ".gitignore" \
+-x "*.md" \
+-x "*.yml" \
+-x "composer.json" \
+-x "composer.lock" \
+-x "*.xml" \
+-x "*.neon" \
+-x "*.dist" \
+-x "*.example" \
+-x "*.DS_Store" \
+
+# Run composer to install dev dependencies, returning enviornment back to original state
+composer update

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,25 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "scripts": {
+        "create-release-assets": [
+            "php -n $(which wp) i18n make-pot . languages/convertkit-mm.pot",
+            "@php .scripts/create-actions-filters-docs.php"
+        ],
+        "create-pot": "php -n $(which wp) i18n make-pot . languages/convertkit-mm.pot",
+        "create-dev-docs": "@php .scripts/create-actions-filters-docs.php",
+        "phpcs": "vendor/bin/phpcs ./ -s -v",
+        "phpcs-tests": "vendor/bin/phpcs ./tests --standard=phpcs.tests.xml -s -v",
+        "phpstan": "vendor/bin/phpstan analyse --memory-limit=1250M",
+        "test": [
+            "vendor/bin/codecept build @no_additional_args",
+            "vendor/bin/codecept run EndToEnd @additional_args --fail-fast"
+        ],
+        "test-integration": [
+            "vendor/bin/codecept build @no_additional_args",
+            "vendor/bin/codecept run Integration @additional_args --fail-fast"
+        ]
+    },
     "archive": {
         "exclude": [
             "!vendor/*",


### PR DESCRIPTION
## Summary

Registers a number of commands in the `scripts` section of Composer, which serve as shorthand commands for testing and other common tasks performed in development, to save repetitively typing longer commands with commonly used flags / arguments.

| Command | Description |
|---------|-------------|
| `create-release-assets` | Generates both the language translation template file (POT) and documentation for actions/filters |
| `create-pot` | Generates just the language translation template file (POT) |
| `create-dev-docs` | Generates just the documentation for actions/filters |
| `phpcs` | Runs PHP CodeSniffer on the entire plugin codebase |
| `phpcs-tests` | Runs PHP CodeSniffer specifically on the tests directory using test-specific standards |
| `phpstan` | Runs PHPStan static analysis with increased memory limit |
| `test` | Builds and runs end-to-end tests with fail-fast enabled |
| `test-integration` | Builds and runs integration tests with fail-fast enabled |

Commands can be run using e.g. `composer test` or `composer phpstan`

<img width="852" alt="Screenshot 2025-06-19 at 20 07 30" src="https://github.com/user-attachments/assets/904b1455-a2dd-472a-a7a4-b773383a5ca2" />

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)