### PR TITLE
Tests: Support Multiple `.env` files

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -209,15 +209,12 @@ jobs:
           echo "CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA=$access_token" >> $GITHUB_ENV
           echo "CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA=$refresh_token" >> $GITHUB_ENV
 
-      # Write any secrets, such as API keys, to the .env.dist.testing file now.
-      # Make sure your committed .env.dist.testing file ends with a newline.
-      # The formatting of the contents to include a blank newline is deliberate.
-      - name: Define GitHub Secrets in .env.dist.testing
-        uses: DamianReeves/write-file-action@v1.2
+      # Write any secrets, such as API keys, to the .env.testing file now.
+      - name: Define GitHub Secrets in .env.testing
+        uses: DamianReeves/write-file-action@v1.3
         with:
-          path: ${{ env.PLUGIN_DIR }}/.env.dist.testing
+          path: ${{ env.PLUGIN_DIR }}/.env.testing
           contents: |
-
             CONVERTKIT_API_KEY=${{ env.CONVERTKIT_API_KEY }}
             CONVERTKIT_API_SECRET=${{ env.CONVERTKIT_API_SECRET }}
             CONVERTKIT_API_KEY_NO_DATA=${{ env.CONVERTKIT_API_KEY_NO_DATA }}
@@ -229,7 +226,7 @@ jobs:
             CONVERTKIT_OAUTH_CLIENT_ID=${{ env.CONVERTKIT_OAUTH_CLIENT_ID }}
             CONVERTKIT_OAUTH_REDIRECT_URI=${{ env.CONVERTKIT_OAUTH_REDIRECT_URI }}
             KIT_OAUTH_REDIRECT_URI=${{ env.KIT_OAUTH_REDIRECT_URI }}
-          write-mode: append
+          write-mode: overwrite
 
       # Installs wp-browser, Codeception, PHP CodeSniffer and anything else needed to run tests.
       - name: Run Composer

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -25,3 +25,4 @@ extensions:
         - lucatume\WPBrowser\Command\ChromedriverUpdate
 params:
     - .env.dist.testing
+    - .env.testing


### PR DESCRIPTION
## Summary

With the upgrade to wp-browser v4 (and consequently Codeception v5), the `codeception.dist.yml` file now takes precedence over a developer’s local `codeception.yml` file:
https://codeception.com/docs/reference/Configuration#Configuration-Templates-distyml

To provide flexibility for local development and GitHub actions, this PR adopts the use of multiple .env files. These files are loaded in sequence, with later files overriding earlier ones, allowing developers to define local credentials, site paths, URLs and other environment-specific settings that may differ from GitHub Actions.

Changes in this PR:
- Configures `codeception.dist.yml` to load both `.env.dist.testing` and `.env.testing`
- Moves sensitive credentials to `.env.testing`, which is excluded from version control
- Updates GitHub Actions to write required sensitive credentials to `.env.testing` at runtime

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)