### PR TITLE
Composer: Add `composer phpcbf` and `composer-phpcbf-tests` commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
         "create-pot": "php -n $(which wp) i18n make-pot . languages/convertkit-mm.pot",
         "create-dev-docs": "@php .scripts/create-actions-filters-docs.php",
         "phpcs": "vendor/bin/phpcs ./ -s -v",
+        "phpcbf": "vendor/bin/phpcbf ./ -s -v",
         "phpcs-tests": "vendor/bin/phpcs ./tests --standard=phpcs.tests.xml -s -v",
+        "phpcbf-tests": "vendor/bin/phpcbf ./tests --standard=phpcs.tests.xml -s -v",
         "phpstan": "vendor/bin/phpstan analyse --memory-limit=1250M",
         "test": [
             "vendor/bin/codecept build @no_additional_args",


### PR DESCRIPTION
## Summary

Registers additional commands in the `scripts` section of Composer, which serve as shorthand commands for testing and other common tasks performed in development, which were missing in #73

| Command | Description |
|---------|-------------|
| `phpcbf` | Runs PHP CodeSniffer on the entire plugin codebase, automatically fixing errors |
| `phpcbf-tests` | Runs PHP CodeSniffer specifically on the tests directory using test-specific standards, automatically fixing errors |

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)