### PR TITLE
Uninstall: Update Token Revokation

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -30,16 +30,14 @@ if ( array_key_exists( 'access_token', $settings ) && ! empty( $settings['access
 		'https://api.kit.com/v4/oauth/revoke',
 		array(
 			'headers' => array(
-				'Accept'       => 'application/json',
-				'Content-Type' => 'application/json',
+				'Content-Type' => 'application/x-www-form-urlencoded',
 			),
-			'body'    => wp_json_encode(
-				array(
-					// Kit for MemberMouse Client ID.
-					// CONVERTKIT_MM_OAUTH_CLIENT_ID cannot be used, as the file its defined in is not available at uninstall time.
-					'client_id' => 'U4aHnnj_QgRrZOdtWUJ6vtpulZSloLKn-7e551T-Exw',
-					'token'     => $settings['access_token'],
-				)
+			'body'    => array(
+				// Kit for MemberMouse Client ID.
+				// CONVERTKIT_MM_OAUTH_CLIENT_ID cannot be used, as the file its defined in is not available at uninstall time.
+				'client_id'       => 'U4aHnnj_QgRrZOdtWUJ6vtpulZSloLKn-7e551T-Exw',
+				'token'           => $settings['access_token'],
+				'token_type_hint' => 'access_token',
 			),
 			'timeout' => 5,
 		)
@@ -52,16 +50,14 @@ if ( array_key_exists( 'refresh_token', $settings ) && ! empty( $settings['refre
 		'https://api.kit.com/v4/oauth/revoke',
 		array(
 			'headers' => array(
-				'Accept'       => 'application/json',
-				'Content-Type' => 'application/json',
+				'Content-Type' => 'application/x-www-form-urlencoded',
 			),
-			'body'    => wp_json_encode(
-				array(
-					// Kit for MemberMouse Client ID.
-					// CONVERTKIT_MM_OAUTH_CLIENT_ID cannot be used, as the file its defined in is not available at uninstall time.
-					'client_id' => 'U4aHnnj_QgRrZOdtWUJ6vtpulZSloLKn-7e551T-Exw',
-					'token'     => $settings['refresh_token'],
-				)
+			'body'    => array(
+				// Kit for MemberMouse Client ID.
+				// CONVERTKIT_MM_OAUTH_CLIENT_ID cannot be used, as the file its defined in is not available at uninstall time.
+				'client_id'       => 'U4aHnnj_QgRrZOdtWUJ6vtpulZSloLKn-7e551T-Exw',
+				'token'           => $settings['refresh_token'],
+				'token_type_hint' => 'refresh_token',
 			),
 			'timeout' => 5,
 		)


### PR DESCRIPTION
## Summary

Updates the token revokation by using `token_type_hint` and setting the request Content-Type to `application/x-www-form-urlencoded`, based on the developer docs at https://developers.kit.com/api-reference/oauth-token-revocation

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)