### PR TITLE
1.4.4.1

### DIFF
--- a/convertkit-membermouse.php
+++ b/convertkit-membermouse.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Kit (formerly ConvertKit) for MemberMouse
  * Plugin URI:        http://www.kit.com
  * Description:       This plugin integrates Kit with MemberMouse.
- * Version:           1.4.4
+ * Version:           1.4.4.1
  * Author:            Kit
  * Author URI:        https://kit.com
  * License:           GPLv3 or later
@@ -34,7 +34,7 @@ define( 'CONVERTKIT_MM_NAME', 'convertkit-mm' ); // Used for settings.
 define( 'CONVERTKIT_MM_FILE', plugin_basename( __FILE__ ) );
 define( 'CONVERTKIT_MM_URL', plugin_dir_url( __FILE__ ) );
 define( 'CONVERTKIT_MM_PATH', plugin_dir_path( __FILE__ ) );
-define( 'CONVERTKIT_MM_VERSION', '1.4.4' );
+define( 'CONVERTKIT_MM_VERSION', '1.4.4.1' );
 define( 'CONVERTKIT_MM_OAUTH_CLIENT_ID', 'U4aHnnj_QgRrZOdtWUJ6vtpulZSloLKn-7e551T-Exw' );
 define( 'CONVERTKIT_MM_OAUTH_CLIENT_REDIRECT_URI', 'https://app.kit.com/wordpress/redirect' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: convertkit, email, marketing, membermouse
 Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 7.1
-Stable tag: 1.4.3
+Stable tag: 1.4.4.1
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -43,7 +43,7 @@ Please report security bugs found in the source code of the plugin through the [
 
 == Changelog ==
 
-### 1.4.4 2026-07-09
+### 1.4.4.1 2026-07-09
 * Fix: Uninstall: Improve Access and Refresh Token revokation
 * Updated: WordPress Libraries to 2.1.7
 


### PR DESCRIPTION
## Summary

Fixes the incorrect version number in the readme.txt which still reads 1.4.3.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)